### PR TITLE
[IMP] account_invoice_supplier_self_invoice: set readonly for can_self_invoice

### DIFF
--- a/account_invoice_supplier_self_invoice/models/account_invoice.py
+++ b/account_invoice_supplier_self_invoice/models/account_invoice.py
@@ -12,7 +12,10 @@ class AccountInvoice(models.Model):
         readonly=True, copy=False
     )
     set_self_invoice = fields.Boolean(string='Set self invoice', copy=False)
-    can_self_invoice = fields.Boolean(related='partner_id.self_invoice')
+    can_self_invoice = fields.Boolean(
+        related='partner_id.self_invoice',
+        readonly=True,
+    )
 
     @api.onchange('partner_id', 'company_id')
     def _onchange_partner_id(self):

--- a/account_invoice_supplier_self_invoice/tests/test_self_invoice.py
+++ b/account_invoice_supplier_self_invoice/tests/test_self_invoice.py
@@ -78,3 +78,10 @@ class TestSelfInvoice(common.TransactionCase):
         self.assertTrue(self.invoice.self_invoice_number)
         new_invoice = self.invoice.copy()
         self.assertFalse(new_invoice.self_invoice_number)
+
+    def test_invoice_write_can_self_invoice(self):
+        self.assertFalse(self.invoice.can_self_invoice)
+        self.invoice.write({'can_self_invoice': True})
+        invoice = self.env['account.invoice'].browse(self.invoice.id)
+        self.assertFalse(invoice.can_self_invoice)
+        self.assertFalse(invoice.partner_id.self_invoice)


### PR DESCRIPTION
This is done to avoid writing over the partner when creating a new invoice through the form.