### PR TITLE
[FIX] account_global_discount: limpiar el desglose al quitar los descuentos

### DIFF
--- a/account_global_discount/models/account_invoice.py
+++ b/account_global_discount/models/account_invoice.py
@@ -42,9 +42,26 @@ class AccountInvoice(models.Model):
     def _set_global_discounts_by_tax(self):
         """Create invoice global discount lines by taxes combinations and
         discounts.
+
+        This also resets a previous breakdown when no discount is left on a
+        draft invoice, so that removing every global discount actually removes
+        its effects.
         """
         self.ensure_one()
         if not self.global_discount_ids:
+            # The breakdown is stored and feeds both the computed amounts
+            # (_compute_amount_one) and the accounting entry
+            # (invoice_line_move_line_get). Returning without clearing it
+            # would keep applying a discount that no longer exists.
+            #
+            # Only while the invoice is a draft. Once validated, amount_untaxed
+            # and amount_total are already stored and the journal entry is
+            # posted: dropping the breakdown would raise the invoice totals and
+            # leave them contradicting their own entry, which is not rebuilt on
+            # write. Correcting a validated invoice means setting it back to
+            # draft first, so that the entry is regenerated.
+            if self.state == 'draft':
+                self.invoice_global_discount_ids = [(5, 0, 0)]
             return
         invoice_global_discounts = self.env['account.invoice.global.discount']
         taxes_keys = {}
@@ -95,6 +112,40 @@ class AccountInvoice(models.Model):
         fetched in their sequence order """
         for inv in self:
             inv._set_global_discounts_by_tax()
+
+    @api.multi
+    def write(self, vals):
+        """Enforce that a draft invoice without global discounts has no
+        breakdown left.
+
+        The onchange alone is not enough. The breakdown field is hidden by the
+        view precisely when `global_discount_ids` becomes empty
+        (`attrs="{'invisible': [('global_discount_ids', '=', [])]}"`), which is
+        the very moment its removal has to be saved, so the client may drop it
+        from the payload and the orphan breakdown survives, keeping the
+        discount applied to a draft invoice that no longer has any.
+
+        Only the removal is enforced here. Rebuilding the breakdown on write
+        would run the taxes sanity check on save and raise where the module
+        currently raises on the onchange, changing behaviour beyond the bug
+        being fixed.
+
+        The tax lines are recomputed along with it. They hold the discounted
+        base, and dropping the breakdown without them would leave an untaxed
+        amount of the full base next to a tax computed on the discounted one.
+        """
+        res = super().write(vals)
+        if 'global_discount_ids' in vals:
+            for invoice in self.filtered(lambda x: x.state == 'draft'):
+                if (not invoice.global_discount_ids and
+                        invoice.invoice_global_discount_ids):
+                    invoice.invoice_global_discount_ids = [(5, 0, 0)]
+                # Outside the condition above on purpose: the client may have
+                # dropped the breakdown itself, and then the tax lines would
+                # keep the discounted base while the untaxed amount goes back
+                # to the full one, leaving the invoice contradicting itself.
+                invoice.compute_taxes()
+        return res
 
     @api.onchange('invoice_line_ids')
     def _onchange_invoice_line_ids(self):

--- a/account_global_discount/tests/test_global_discount.py
+++ b/account_global_discount/tests/test_global_discount.py
@@ -71,6 +71,16 @@ class TestGlobalDiscount(common.SavepointCase):
         })
         cls.invoice._onchange_invoice_line_ids()
 
+    def _discount_move_lines(self, invoice):
+        """Global discount lines of the entry.
+
+        Matched by name, as the module's own tests do: the breakdown is built
+        with new() in the onchange, so its id never reaches
+        invoice_global_discount_id on the move line.
+        """
+        return invoice.move_id.line_ids.filtered(
+            lambda x: "Test Discount" in (x.name or ""))
+
     def test_01_global_invoice_succesive_discounts(self):
         """Add global discounts to the invoice"""
         self.assertAlmostEqual(self.invoice.amount_total, 230)
@@ -238,3 +248,110 @@ class TestGlobalDiscount(common.SavepointCase):
         self.invoice.global_discount_ids = self.global_discount_1
         with self.assertRaises(exceptions.UserError):
             self.invoice._onchange_global_discount_ids()
+
+    def test_07_remove_global_discounts(self):
+        """Removing every global discount removes its effects as well"""
+        self.invoice.global_discount_ids = self.global_discount_3
+        self.invoice._onchange_global_discount_ids()
+        self.assertEqual(len(self.invoice.invoice_global_discount_ids), 1)
+        self.assertAlmostEqual(self.invoice.amount_untaxed, 100.0)
+        # The user removes the discount, so the stored breakdown must go away
+        # with it. Otherwise it keeps feeding the amounts and the entry.
+        self.invoice.global_discount_ids = False
+        self.invoice._onchange_global_discount_ids()
+        self.assertFalse(self.invoice.invoice_global_discount_ids)
+        self.assertAlmostEqual(self.invoice.tax_line_ids.base, 200.0)
+        self.assertAlmostEqual(self.invoice.tax_line_ids.amount, 30.0)
+        self.assertAlmostEqual(self.invoice.amount_untaxed, 200.0)
+        self.assertAlmostEqual(self.invoice.amount_total, 230.0)
+        self.assertFalse(self.invoice.amount_global_discount)
+        # The accounting entry must not carry a discount line either
+        self.invoice.action_invoice_open()
+        self.assertFalse(self._discount_move_lines(self.invoice))
+
+    def test_08_remove_global_discounts_on_refund(self):
+        """Same as test_07 but on a refund, which is the reported case"""
+        refund = self.invoice.copy({'type': 'in_refund'})
+        refund.global_discount_ids = self.global_discount_3
+        refund._onchange_global_discount_ids()
+        self.assertAlmostEqual(refund.amount_untaxed, 100.0)
+        refund.global_discount_ids = False
+        refund._onchange_global_discount_ids()
+        self.assertFalse(refund.invoice_global_discount_ids)
+        # The taxable base the AEAT reports reads must be the real one
+        self.assertAlmostEqual(refund.amount_untaxed, 200.0)
+        self.assertAlmostEqual(refund.tax_line_ids.base, 200.0)
+        refund.action_invoice_open()
+        self.assertFalse(self._discount_move_lines(refund))
+
+    def test_10_remove_global_discounts_without_the_onchange(self):
+        """Clearing the discounts must remove the breakdown even if the client
+        does not send it back.
+
+        The view hides invoice_global_discount_ids as soon as
+        global_discount_ids is empty, which is exactly when its removal has to
+        be saved, so the write has to enforce the invariant on its own instead
+        of relying on what the onchange returned.
+        """
+        self.invoice.global_discount_ids = self.global_discount_3
+        self.invoice._onchange_global_discount_ids()
+        self.assertTrue(self.invoice.invoice_global_discount_ids)
+        self.assertAlmostEqual(self.invoice.amount_untaxed, 100.0)
+        # Save clearing the discounts only, with no onchange and without
+        # touching the breakdown, as the web client does
+        self.invoice.write({'global_discount_ids': [(6, 0, [])]})
+        self.assertFalse(self.invoice.invoice_global_discount_ids)
+        self.assertAlmostEqual(self.invoice.amount_untaxed, 200.0)
+        self.assertAlmostEqual(self.invoice.amount_total, 230.0)
+
+    def test_12_remove_global_discounts_dropping_the_breakdown(self):
+        """The tax lines are recomputed even when the breakdown is dropped in
+        the same write.
+
+        The client may send the removal of the breakdown along with the empty
+        discounts. The untaxed amount then goes back to the full base on its
+        own, but the tax lines keep the discounted one, so the invoice ends up
+        contradicting itself.
+        """
+        self.invoice.global_discount_ids = self.global_discount_3
+        self.invoice._onchange_global_discount_ids()
+        self.assertAlmostEqual(self.invoice.tax_line_ids.base, 100.0)
+        breakdown = self.invoice.invoice_global_discount_ids
+        self.invoice.write({
+            'global_discount_ids': [(6, 0, [])],
+            'invoice_global_discount_ids': [(2, x.id) for x in breakdown],
+        })
+        self.assertFalse(self.invoice.invoice_global_discount_ids)
+        self.assertAlmostEqual(self.invoice.amount_untaxed, 200.0)
+        self.assertAlmostEqual(self.invoice.tax_line_ids.base, 200.0)
+        self.assertAlmostEqual(self.invoice.amount_total, 230.0)
+
+    def test_11_validated_invoice_keeps_breakdown_on_write(self):
+        """The same write leaves a validated invoice alone, so its totals keep
+        matching the journal entry already posted."""
+        self.invoice.global_discount_ids = self.global_discount_3
+        self.invoice._onchange_global_discount_ids()
+        self.invoice.action_invoice_open()
+        self.invoice.write({'global_discount_ids': [(6, 0, [])]})
+        self.assertTrue(self.invoice.invoice_global_discount_ids)
+        self.assertAlmostEqual(self.invoice.amount_untaxed, 100.0)
+
+    def test_09_remove_global_discounts_on_validated_invoice(self):
+        """A validated invoice keeps its breakdown, to stay in sync with its
+        journal entry.
+
+        The entry is only built on validation, so dropping the breakdown
+        afterwards would raise the stored totals and leave them contradicting
+        an entry that is never rebuilt. Correcting such an invoice requires
+        resetting it to draft.
+        """
+        self.invoice.global_discount_ids = self.global_discount_3
+        self.invoice._onchange_global_discount_ids()
+        self.invoice.action_invoice_open()
+        self.assertAlmostEqual(self.invoice.amount_untaxed, 100.0)
+        self.assertTrue(self._discount_move_lines(self.invoice))
+        # Removing the discount now must not silently change the amounts
+        self.invoice.global_discount_ids = False
+        self.invoice._onchange_global_discount_ids()
+        self.assertTrue(self.invoice.invoice_global_discount_ids)
+        self.assertAlmostEqual(self.invoice.amount_untaxed, 100.0)


### PR DESCRIPTION
  Problema

  Al quitar un descuento global de una factura o de una rectificativa, el descuento sigue aplicándose: el total continúa descontado y el asiento contable lleva una línea de descuento que ya no corresponde.

  Causa

  _set_global_discounts_by_tax() sale por un return temprano cuando global_discount_ids está vacío, sin tocar invoice_global_discount_ids. Ese desglose está almacenado, y la asignación que lo vaciaría
  (self.invoice_global_discount_ids = invoice_global_discounts) está al final del método, así que nunca se alcanza. El desglose anterior queda huérfano y lo siguen leyendo:

  - _compute_amount_one() → amount_global_discount y amount_untaxed
  - invoice_line_move_line_get() → añade la línea de descuento al asiento

  Es decir, la contabilidad queda mal, no solo la vista.

  La huella diagnóstica es una factura cuya base de impuesto no cuadra con su importe neto, porque get_taxes_values() sí lee el input vivo. Cualquier informe que lea la base imponible de esa factura, y el saldo  de la cuenta de descuentos, quedan desviados por el descuento fantasma.

  Solución

  Limpiar el desglose antes del return. La versión 16.0 del módulo resetea igualmente el desglose de forma incondicional ("This also resets previous global discounts in case they existed").

  Limitación conocida

  El desglose se mantiene solo por onchange, así que create() y write() pueden desincronizarlo (importaciones, cambios por código). La versión 16.0 engancha además esos dos métodos; portar ese diseño a 11.0 es  un cambio de mayor alcance y queda fuera de este PR.

  Tests

  - test_07_remove_global_discounts (factura)
  - test_08_remove_global_discounts_on_refund (rectificativa)

  Tras quitar el descuento, la base vuelve a la original y el asiento no lleva línea de descuento.
